### PR TITLE
replaced substr to mb_substr to support mutli-language strings

### DIFF
--- a/thawani-pay-woocommerce.php
+++ b/thawani-pay-woocommerce.php
@@ -260,7 +260,7 @@ add_action( 'admin_print_styles', 'plugin_scripts' );
           // $subtotal_tax = $item->get_subtotal_tax(); // Line subtotal tax
           // $price_incl_tax = ( $subtotal + $subtotal_tax ) / $quantity;
 
-          array_push($products_list, array('name'=> substr($product_name, 0, 39), 'unit_amount' => $price_excl_tax * 1000, 'quantity' => $quantity));
+          array_push($products_list, array('name'=> mb_substr($product_name, 0, 39, 'utf-8'), 'unit_amount' => $price_excl_tax * 1000, 'quantity' => $quantity));
         }
 
         //check for shipping cost to be added as product item on Thawani checkout api.


### PR DESCRIPTION
as you can see `substr` is not working well with Arabic characters while `mb_substr()` is a multibyte-safe version of `substr()`.

below shows the usage of `substr()` and `mb_substr()`
![image](https://user-images.githubusercontent.com/38052394/129496368-8187ba01-8cb3-4c8d-8a93-0d31f90bf168.png)

![image](https://user-images.githubusercontent.com/38052394/129496520-5fe49976-69da-48e2-880c-3650a7423234.png)

to make mb_substr works, php-mbstring should be installed.


reference: https://www.php.net/manual/en/function.mb-substr.php