### PR TITLE
New Order email after payment Success

### DIFF
--- a/thawani-pay-woocommerce.php
+++ b/thawani-pay-woocommerce.php
@@ -330,7 +330,11 @@ add_action( 'admin_print_styles', 'plugin_scripts' );
               $invoice_id = $response['data']['invoice'];
               update_post_meta( $order_id, 'session_id', $session_id);
               update_post_meta( $order_id, 'invoice_id', $invoice_id);
-
+              
+              // Trigger WooCommerce new order email to both
+              $wc_emails = WC()->mailer()->get_emails();
+              $wc_emails['WC_Email_New_Order']->trigger( $order_id );
+              
               $redirect_url = $thawani_api . "/pay/" . $session_id. '?key=' . $publishable_key;
               return array(
                 'result'   => 'success',


### PR DESCRIPTION
# Issue:
   New order and order processing email was not sent after payment success
# Solution:
   1- Added hard coded solution to send both email using WooCommerce 'WC_Email_New_Order' and 'WC_Email_Customer_Processing_Order' email triggers